### PR TITLE
s/pattern/path

### DIFF
--- a/foobar/foobar.routing.yml
+++ b/foobar/foobar.routing.yml
@@ -1,26 +1,26 @@
 foobar:
-  pattern: 'admin/foobar'
+  path: 'admin/foobar'
   defaults:
     _content: '\Drupal\foobar\Controller\FoobarController::foobarPage'
   requirements:
     _permission: 'access administration pages'
 
 foobar.form:
-  pattern: 'admin/foobar/form'
+  path: 'admin/foobar/form'
   defaults:
     _form: '\Drupal\foobar\Form\FoobarForm'
   requirements:
     _permission: 'access administration pages'
 
 foobar.systemconfigformbase:
-  pattern: 'admin/foobar/systemconfigformbase'
+  path: 'admin/foobar/systemconfigformbase'
   defaults:
     _form: '\Drupal\foobar\Form\FoobarConfigForm'
   requirements:
     _permission: 'access administration pages'
 
 foobar.drupal_get_form:
-  pattern: 'admin/foobar/drupal_get_form'
+  path: 'admin/foobar/drupal_get_form'
   defaults:
     _content: '\Drupal\foobar\Controller\FoobarController::foobarDrupalGetFormPage'
   requirements:

--- a/foobar/lib/Drupal/foobar/Plugin/Block/FoobarBlock.php
+++ b/foobar/lib/Drupal/foobar/Plugin/Block/FoobarBlock.php
@@ -8,13 +8,13 @@
 namespace Drupal\foobar\Plugin\Block;
 
 use Drupal\block\BlockBase;
-use Drupal\Component\Annotation\Plugin;
+use Drupal\block\Annotation\Block;
 use Drupal\Core\Annotation\Translation;
 
 /**
  * Provides a 'Foobar' block.
  *
- * @Plugin(
+ * @Block(
  *   id = "foobar_foobar_block",
  *   admin_label = @Translation("Foobar"),
  *   module = "foobar"


### PR DESCRIPTION
Hi, 

I was running through your tutorial here - http://getlevelten.com/blog/ian-whitcomb/drupal-8-module-development-part-1-getting-started as part of getting up to speed with d8. 

However, my menu items weren't showing up because Drupal 8 now expects "path", not "pattern" in the routing.yml file - see https://drupal.org/node/2051097